### PR TITLE
Updates to signature processing to reflect "hash to curve" v7.

### DIFF
--- a/deposit_contract_proxy.sol
+++ b/deposit_contract_proxy.sol
@@ -268,7 +268,7 @@ library BLSSignature {
         require(success, "call to addition in G2 precompile failed");
     }
 
-    // Implements v6 of "hash to the curve" of the IETF BLS draft.
+    // Implements "hash to the curve" from the IETF BLS draft.
     function hashToCurve(bytes32 message) private view returns (G2Point memory) {
         Fp2[2] memory messageElementsInField = hashToField(message);
         G2Point memory firstPoint = mapToCurve(messageElementsInField[0]);

--- a/deposit_contract_proxy.sol
+++ b/deposit_contract_proxy.sol
@@ -67,7 +67,7 @@ library BLSSignature {
     uint8 constant BLS12_381_MAP_FIELD_TO_CURVE_PRECOMPILE_ADDRESS = 0xB;
     uint8 constant BLS12_381_G2_ADD_ADDRESS = 0xC;
     uint8 constant BLS12_381_G2_MULTIPLY_ADDRESS = 0xD;
-    string constant BLS_SIG_DST = "+BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+    string constant BLS_SIG_DST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_+";
     uint8 constant MOD_EXP_PRECOMPILE_ADDRESS = 0x5;
 
     // Fp is a field element with the high-order part stored in `a`.


### PR DESCRIPTION
Following this PR: https://github.com/ethereum/py_ecc/pull/94


It seems like the only change for "hash to curve" v7 is to re-order how the "DST" is computed.
 refer to the diff in : `py_ecc/bls/hash.py` in that PR.

the other changes happen behind the interface of the "map field to curve" precompile...